### PR TITLE
replace wtf-is with metaboss

### DIFF
--- a/src/docs-bot/commands.ts
+++ b/src/docs-bot/commands.ts
@@ -71,7 +71,7 @@ const slashCommands: CommandObject[] = [
     {
         data: {
             name: 'wtf-is',
-            description: 'What specific Metaplex errors mean! Uses the wtf-is Rust crate under the hood.',
+            description: 'What specific Metaplex errors mean! Uses the metaboss Rust crate under the hood.',
             defaultPermission: true,
             options: [
                 {

--- a/src/docs-bot/wtf-is.ts
+++ b/src/docs-bot/wtf-is.ts
@@ -6,7 +6,7 @@ export async function wtfIs(interaction: CommandInteraction) {
     const query = interaction.options.getString('code', true);
     const hidden = interaction.options.getBoolean('hidden');
 
-    await interaction.deferReply({ ephemeral: hidden ?? false });
+    await interaction.deferReply({ ephemeral: hidden ?? true });
 
     // Uses the `wtf-is` crate made by Sam Vanderwaal.
     // https://crates.io/crates/wtf-is/0.3.0

--- a/src/docs-bot/wtf-is.ts
+++ b/src/docs-bot/wtf-is.ts
@@ -8,11 +8,16 @@ export async function wtfIs(interaction: CommandInteraction) {
 
     await interaction.deferReply({ ephemeral: hidden ?? true });
 
-    // Uses the `wtf-is` crate made by Sam Vanderwaal.
-    // https://crates.io/crates/wtf-is/0.3.0
-    const execFile = util.promisify(child_process.execFile);
-    const { stdout } = await execFile('wtf-is', [query]);
-
-    const message = `**Response from *wtf-is*:**\n${stdout}`;
+    let response;
+    try {
+        // Uses the `metaboss` crate made by Sam Vanderwaal.
+        // https://crates.io/crates/metaboss
+        const execFile = util.promisify(child_process.execFile);
+        const stdout = await (await execFile('metaboss', ['find','error',query])).stdout;
+        response = stdout.replace('Done!','')
+    } catch (e) {
+        response = `Error: Invalid Error Code ${query}`;
+    }
+    const message = `**Response from *metaboss find error*:**\n${response}`;
     await interaction.editReply(message);
 }


### PR DESCRIPTION
Since the wtf-is binary is deprecated larry should use metaboss instead to always have the latest error codes.

Also made /wtf-is hidden by default to avoid clutter in the chat.

**Caution:** make sure that the metaboss binary is installed when deploying to the server.